### PR TITLE
Fix url error that breaks the packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,0 @@
-Fork of flathub qqmusic to solve url error
-
-qq音乐，解决了地址错误问题

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
 Fork of flathub qqmusic to solve url error
+
 qq音乐，解决了地址错误问题

--- a/README.md
+++ b/README.md
@@ -1,0 +1,2 @@
+Fork of flathub qqmusic to solve url error
+qq音乐，解决了地址错误问题

--- a/com.qq.QQmusic.yml
+++ b/com.qq.QQmusic.yml
@@ -45,14 +45,14 @@ modules:
         path: com.qq.QQmusic.metainfo.xml
       - type: extra-data
         filename: qqmusic_amd64.deb
-        url: https://dldir1.qq.com/music/clntupate/linux/deb/qqmusic_1.1.5_amd64.deb
+        url: https://dldir1.qq.com/music/clntupate/linux/deb/qqmusic_1.1.5_amd64_.deb
         sha256: c13b4ef344bca38fc47950af07368de31b48dfe9928538cd1e9ab8d5ec5f3fe8
         size: 77742406
         x-checker-data:
           type: html
           url: https://y.qq.com/download/download.html
-          version-pattern: linux/deb/qqmusic_(\S*)_amd64.deb
-          url-template: https://dldir1.qq.com/music/clntupate/linux/deb/qqmusic_${version}_amd64.deb
+          version-pattern: linux/deb/qqmusic_(\S*)_amd64_.deb
+          url-template: https://dldir1.qq.com/music/clntupate/linux/deb/qqmusic_${version}_amd64_.deb
     buildsystem: simple
     build-commands:
       - install -D -m 755 -t /app/bin/ qqmusic.sh


### PR DESCRIPTION
Tecent has somehow change url of `qqmusic` to `https://dldir1.qq.com/music/clntupate/linux/deb/qqmusic_1.1.5_amd64_.deb` ( see here is a `_` now before `.deb` ). However such change is absent in flathub repo so that now the package will not install.

I have added such change